### PR TITLE
Display saved palettes functionality

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -5,10 +5,11 @@ var displayedHexCode = document.querySelectorAll('.hex-code')
 var paletteBox = document.querySelector('.palettes')
 var paletteId = document.querySelectorAll('.palettes__color')
 var lockImg = document.querySelectorAll('.lock')
-var savePaletteButton = document.querySelector('.buttons__save-palette');
+var savePaletteButton = document.querySelector('.buttons__save-palette')
 var sidebar = document.querySelector('.sidebar')
 var miniPalette = document.getElementsByClassName('mini__palette')
-var sidebarInstance = document.querySelectorAll('.sidebar__new-instance')
+var sidebarInstance = document.getElementsByClassName('sidebar__new-instance')
+// var tinyPalette = document.getElementsByClassName('mini__palette')
 
 
 var currentPalette;
@@ -23,17 +24,18 @@ paletteBox.addEventListener('click', function(event){
 });
 
 newPalette.addEventListener('click', function(){
-	newPaletteInstance()
+	newPaletteInstance();
+	savePaletteToggle();
 })
 
-savePaletteButton.addEventListener('click', function() {
+savePaletteButton.addEventListener('click', function() {	
 	saveCurrentPalette();
 	addMiniPalettesHTML();
-	displayMiniPalettes();
-	console.log(sidebarInstance);
+	// displayMiniPalettes();
 })
 
 function saveCurrentPalette() {
+	savePaletteButton.disabled = true;
 	if(!savedPalettes.includes(currentPalette)) {
 		// for(var i = 0; i < currentPalette.length; i++) {
 		// 	if(currentPalette.colors[i].locked) {
@@ -91,29 +93,35 @@ function generateNewPalette() {
 }
 
 function addMiniPalettesHTML(){
-	var newInnerHTML = `
+	sidebar.innerHTML += `
 	<section class="sidebar__new-instance">
-	<section class="mini__palette"></section>
-	<section class="mini__palette"></section>
-	<section class="mini__palette"></section>
-	<section class="mini__palette"></section>
-	<section class="mini__palette"></section>
-	<section class="mini__trashcan"></section>
+	<section class="mini__palette" style='background-color:${savedPalettes[0].colors[0].hexCode}'></section>
+	<section class="mini__palette" style='background-color:${savedPalettes[0].colors[1].hexCode}'></section>
+	<section class="mini__palette" style='background-color:${savedPalettes[0].colors[2].hexCode}'></section>
+	<section class="mini__palette" style='background-color:${savedPalettes[0].colors[3].hexCode}'></section>
+	<section class="mini__palette" style='background-color:${savedPalettes[0].colors[4].hexCode}'></section>
+	<section class="mini__trashcan" id='${savedPalettes[0].id}'></section>
   </section>`
-
-  sidebar.innerHTML += newInnerHTML;
-  for (var i = 0; i < 5; i++) {
-	  
-	  miniPalette[i].style.backgroundColor = savedPalettes[0].colors[i].hexCode;
-	}
-
 }
 
-function displayMiniPalettes(){
-	for (var i = 0; i < 5; i++) {
-
-	miniPalette[i].style.backgroundColor = savedPalettes[0].colors[i].hexCode;
-	}
+function savePaletteToggle() {
+	if(savePaletteButton.disabled) {
+		savePaletteButton.disabled = false;
+	} 
 }
-	
 
+
+
+// function displayMiniPalettes(test){
+// 				test[1].style.backgroundColor = savedPalettes[0].colors[0].hexCode;
+// 				test[3].style.backgroundColor = savedPalettes[0].colors[1].hexCode;
+// 				test[5].style.backgroundColor = savedPalettes[0].colors[2].hexCode;
+// 				test[7].style.backgroundColor = savedPalettes[0].colors[3].hexCode;
+// 				test[9].style.backgroundColor = savedPalettes[0].colors[4].hexCode;
+// 			}
+
+// 	function test() {
+// 		console.log(sidebarInstance)
+// 			var test = sidebarInstance[sidebarInstance.length-1].childNodes
+// 			displayMiniPalettes(test)
+// 	}

--- a/styles.css
+++ b/styles.css
@@ -99,7 +99,7 @@
 	flex-direction: column;
 	align-items: center;
 	justify-content: flex-start;
-	overflow-y: auto;
+	overflow-y: scroll;
 	overflow-x: hidden;
 }
 
@@ -120,9 +120,9 @@
 }
 
 .mini__palette {
-	height: 70%;
+	height: 65%;
 	width: 15%;
-	border: 1px solid blue;
+	border: 1px solid black;
 }
 
 .mini__trashcan {


### PR DESCRIPTION
# Description
This pull request will add our display-saved palettes functionality. Users can now click the save palette button and add their current displayed palette to a list of displayed palettes. 

## Issues
Due to the code not being dry we had to scrap our original method and use inline interpolation to add our saved palettes. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring

# How Has This Been Tested?
- [x] open localHost
- [x] dev tools

# Checklist:
- [x] My code follows Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages
