### PR TITLE
Reformat class files and delete unused DOM elements

### DIFF
--- a/color-class.js
+++ b/color-class.js
@@ -14,17 +14,3 @@ class Color {
 		return result
 	}
 }
-
-class Palette {
-	constructor(colors) {
-		this.colors = colors
-		this.id = Date.now();
-	}
-	makeLocked(id) {
-		this.colors[id].locked = true;
-	}
-	makeUnlocked(id){
-		this.colors[id].locked = false;
-	}
-
-}

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
       </section>
     </section>
   </body>
-  <script type="text/javascript" src="classes.js"></script>
+  <script type="text/javascript" src="color-class.js"></script>
+  <script type="text/javascript" src="palette-class.js"></script>
   <script type="text/javascript" src="scripts.js"></script>
 </html>

--- a/palette-class.js
+++ b/palette-class.js
@@ -1,0 +1,13 @@
+class Palette {
+	constructor(colors) {
+		this.colors = colors
+		this.id = Date.now();
+	}
+	makeLocked(id) {
+		this.colors[id].locked = true;
+	}
+	makeUnlocked(id){
+		this.colors[id].locked = false;
+	}
+
+}

--- a/scripts.js
+++ b/scripts.js
@@ -2,14 +2,11 @@
 var newPalette = document.querySelector('.buttons__new-palette');
 var currentColors = document.querySelectorAll('.palettes__current');
 var displayedHexCode = document.querySelectorAll('.hex-code');
-var paletteBox = document.querySelector('.palettes')
-var paletteId = document.querySelectorAll('.palettes__color');
+var paletteBox = document.querySelector('.palettes');
 var lockImg = document.querySelectorAll('.lock');
 var savePaletteButton = document.querySelector('.buttons__save-palette');
 var sidebar = document.querySelector('.sidebar');
 var miniPalette = document.getElementsByClassName('mini__palette');
-var sidebarInstance = document.getElementsByClassName('sidebar__new-instance');
-var trashIcon = document.querySelector(".mini__trashcan");
 
 //~~~~~~~~~~~~~~~~~~~~~~~Global Variables~~~~~~~~~~~~~~~~~~~~~~
 var currentPalette;
@@ -116,4 +113,3 @@ function savePaletteToggle() {
 		savePaletteButton.disabled = false;
 	}
 }
-


### PR DESCRIPTION
# Description
Removes color class from file containing palette class and creates a separate file for colors. Also, removes unused DOM elements.

## Issues


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring

# How Has This Been Tested?
- [x] open localHost
- [x] dev tools

# Checklist:
- [x] My code follows the Turing's guidelines of this project
- [x] I have performed a self-review of my own code
- [x] No console error messages
